### PR TITLE
fix: menghilangkan `env` continous integration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,8 +29,6 @@ jobs:
         run: |
           npx lerna bootstrap
           npx lerna link
-        env:
-          CI: TRUE
 
       - name: Linting
         run: npm run lint


### PR DESCRIPTION
## Deskripsi

Pull request ini mencoba memperbaiki github action yang error di https://github.com/bellshade/bellshade-monorepo/runs/5552966724?check_suite_focus=true

## Environment

Saya menggunakan:

- `os` = `Linux`